### PR TITLE
SAODB-132 - MA/AC - Create stub and skeleton tests for submitting a registration

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,7 +4,7 @@ binPack.parentConstructors = false
 indent.callSite = 2
 indent.defnSite = 2
 align.preset = most
-align.tokens = [ {code = "=>", owner = "Case|Type.Arg.ByName"}, "=", "<-", "->", "%", "%%", "should", "shouldBe", "shouldEqual", "shouldNot", "must" ]
+align.tokens = [ {code = "=>", owner = "Case|Type.Arg.ByName"}, "=", "<-", "->", "%", "%%"]
 align.arrowEnumeratorGenerator = true
 align.openParenCallSite = false
 align.openParenDefnSite = false

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,8 @@ import sbt.*
 object Dependencies {
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc" %% "api-test-runner" % "0.9.0" % Test
+    "uk.gov.hmrc"   %% "api-test-runner" % "0.9.0"  % Test,
+    "org.scalatest" %% "scalatest"       % "3.2.19" % Test
   )
 
 }

--- a/src/test/scala/uk/gov/hmrc/api/specs/BusinessEntityApiSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/api/specs/BusinessEntityApiSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.api.specs
+
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.stubs.TestDataFactory
+import java.util.UUID
+
+class BusinessEntityApiSpec extends BaseSpec {
+
+  "The business entity registration API" must {
+
+    "when submitting a registration" must {
+      "succeed with valid data" in {
+        val businessEntity = TestDataFactory.validBusinessEntity()
+        whenReady(request.put(businessEntity)) { response =>
+          response.body must include("Business entity updated successfully")
+          response.statusCode mustBe 200
+        }
+      }
+
+      "reject a duplicate registration" in {
+        val businessEntity = TestDataFactory.duplicateBusinessEntity()
+        whenReady(request.put(businessEntity)) { response =>
+          response.body must include("Business entity already exists")
+          response.statusCode mustBe 409
+        }
+      }
+
+      "reject invalid business entity data" in {
+        val businessEntity = TestDataFactory.invalidBusinessEntity()
+        whenReady(request.put(businessEntity)) { response =>
+          response.body must include("Invalid business entity data")
+          response.statusCode mustBe 400
+        }
+      }
+
+      "require request body" in {
+        whenReady(request.putWithNoBody()) { response =>
+          response.body must include("Request body is required")
+          response.statusCode mustBe 400
+        }
+      }
+
+      "require valid content type header" in {
+        val businessEntity = TestDataFactory.validBusinessEntity()
+        whenReady(request.putWithInvalidContentType(businessEntity)) { response =>
+          response.body must include("Content-Type must be application/json")
+          response.statusCode mustBe 400
+        }
+      }
+    }
+
+    "when retrieving a registration" must {
+
+      "return a business entity for a valid ID" in {
+        val validUUID = UUID.randomUUID()
+        whenReady(request.get(validUUID)) { response =>
+          response.body must include(validUUID.toString)
+          response.body must include("Test Company Ltd")
+          response.statusCode mustBe 200
+        }
+      }
+
+      "return 'not found' for missing entity" in {
+        val nonExistentId = "00000000-0000-0000-0000-000000000000"
+        whenReady(request.get(nonExistentId)) { response =>
+          response.body must include("Business entity not found")
+          response.statusCode mustBe 404
+        }
+      }
+
+      "reject invalid UUID format" in {
+        whenReady(request.get("not-a-uuid")) { response =>
+          response.body must include("Invalid UUID format")
+          response.statusCode mustBe 400
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/stubs/BusinessEntityApiStub.scala
+++ b/src/test/scala/uk/gov/hmrc/stubs/BusinessEntityApiStub.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.stubs
+
+import uk.gov.hmrc.stubs.models.BusinessEntity
+import play.api.libs.json.{JsValue, Json}
+
+import scala.concurrent.Future
+import java.util.UUID
+import scala.util.{Failure, Success, Try}
+
+/** Pure stub implementation for business entity registration API.
+  *
+  * This stub provides pre-determined responses based on JSON content patterns.
+  *
+  * TODO: (24/09) MA - Make a card to remove this file when the actual API implementation is built and implemented.
+  */
+
+case class ApiResponse(statusCode: Int, body: String)
+
+object BusinessEntityApiStub {
+
+  private val basePath = "/senior-accounting-officer-hod/business-entity"
+
+  def call(
+    method: String,
+    url: String,
+    body: Option[JsValue] = None,
+    contentType: String = "application/json"
+  ): Future[ApiResponse] =
+    (method.toUpperCase, url) match {
+      case ("PUT", basePath) =>
+        validateAndCallPutRequest(body, contentType)
+
+      case ("GET", path) if path.startsWith(s"$basePath/") =>
+        val id = path.replace(s"$basePath/", "")
+        validateAndCallGetRequest(id)
+    }
+
+  private def validateAndCallPutRequest(requestBody: Option[JsValue], contentType: String): Future[ApiResponse] = {
+    if (contentType != "application/json") return badRequest("Content-Type must be application/json")
+
+    requestBody match {
+      case None => badRequest("Request body is required")
+
+      case Some(body) =>
+        body
+          .validate[BusinessEntity]
+          .fold(
+            errors => badRequest("Invalid JSON format"),
+            businessEntity => processEntity(businessEntity)
+          )
+    }
+  }
+
+  private def processEntity(businessEntity: BusinessEntity): Future[ApiResponse] =
+    businessEntity.name match {
+      case "" => badRequest("Invalid business entity data")
+
+      case "DuplicateCompany" =>
+        Future.successful(
+          ApiResponse(409, errorMessage("Business entity already exists"))
+        )
+
+      case _ =>
+        Future.successful(
+          ApiResponse(200, s"""{"message":"Business entity updated successfully","id":"${businessEntity.id}"}""")
+        )
+    }
+
+  private def validateAndCallGetRequest(id: String): Future[ApiResponse] =
+    Try(UUID.fromString(id)) match {
+      case Failure(_) =>
+        badRequest("Invalid UUID format")
+
+      case Success(_) if id == "00000000-0000-0000-0000-000000000000" =>
+        Future.successful(ApiResponse(404, errorMessage("Business entity not found")))
+
+      case Success(uuid) =>
+        val stubEntity = TestDataFactory.validBusinessEntity().copy(id = uuid)
+        Future.successful(ApiResponse(200, Json.toJson(stubEntity).toString()))
+    }
+
+  private def badRequest(message: String): Future[ApiResponse] =
+    Future.successful(ApiResponse(400, errorMessage(message)))
+
+  private def errorMessage(message: String): String = s"""{"error":"$message"}"""
+
+}

--- a/src/test/scala/uk/gov/hmrc/stubs/TestDataFactory.scala
+++ b/src/test/scala/uk/gov/hmrc/stubs/TestDataFactory.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.stubs
+
+import uk.gov.hmrc.stubs.enums.ContactTypeOrder.First
+import uk.gov.hmrc.stubs.models.{AccountingPeriod, BusinessEntity, Contact, Submission}
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+
+object TestDataFactory {
+
+  private object Defaults {
+    val companyName  = "Valid Test Company Ltd"
+    val crn          = "12345678"
+    val utr          = "1234567890"
+    val contactName  = "Jamaica John"
+    val contactRole  = "Officer"
+    val contactPhone = "+44 20 1234 5678"
+    val testDomain   = "testCompany.com"
+  }
+
+  def validBusinessEntity(
+    id: UUID = UUID.randomUUID(),
+    name: String = Defaults.companyName,
+    crn: String = Defaults.crn,
+    utr: String = Defaults.utr
+  ): BusinessEntity = BusinessEntity(
+    id = id,
+    crn = crn,
+    utr = utr,
+    name = name,
+    contacts = List(validContact()),
+    submissions = Some(List(validSubmission())),
+    createdAt = Instant.now()
+  )
+
+  def invalidBusinessEntity(): BusinessEntity = validBusinessEntity().copy(
+    crn = "",
+    utr = "",
+    name = "",
+    contacts = List.empty,
+    submissions = None
+  )
+
+  def duplicateBusinessEntity(): BusinessEntity =
+    validBusinessEntity().copy(name = "DuplicateCompany")
+
+  def validContact(
+    name: String = Defaults.contactName,
+    role: String = Defaults.contactRole
+  ): Contact = Contact(
+    name = name,
+    role = role,
+    email = emailFor(name),
+    phone = Defaults.contactPhone,
+    order = First
+  )
+
+  def validSubmission(): Submission = Submission(
+    accountingPeriod = Some(validAccountingPeriod()),
+    receivedDate = Instant.now()
+  )
+
+  def validAccountingPeriod(): AccountingPeriod = {
+    val start = oneYearAgo
+    AccountingPeriod(
+      startDate = start,
+      endDate = start.plus(365, ChronoUnit.DAYS),
+      dueDate = start.plus(395, ChronoUnit.DAYS)
+    )
+  }
+
+  private def emailFor(name: String) = s"${name.toLowerCase.replace(" ", ".")}@${Defaults.testDomain}"
+
+  private def oneYearAgo = Instant.now().minus(365, ChronoUnit.DAYS)
+}

--- a/src/test/scala/uk/gov/hmrc/stubs/enums/ContactTypeOrder.scala
+++ b/src/test/scala/uk/gov/hmrc/stubs/enums/ContactTypeOrder.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.stubs.enums
+
+import play.api.libs.json.*
+
+import scala.util.Try
+
+enum ContactTypeOrder {
+  case First, Second, Third
+}
+
+object ContactTypeOrder {
+
+  given Format[ContactTypeOrder] = new Format[ContactTypeOrder] {
+    def writes(contactTypeOrder: ContactTypeOrder): JsValue =
+      JsString(contactTypeOrder.toString)
+
+    def reads(json: JsValue): JsResult[ContactTypeOrder] = json match {
+      case JsString(value) =>
+        Try(ContactTypeOrder.valueOf(value))
+          .map(JsSuccess(_))
+          .getOrElse(JsError(s"Unknown ContactTypeOrder value: $value"))
+
+      case _ => JsError("ContactTypeOrder must be a string (e.g. \"Second\")")
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/stubs/enums/ContactTypeOrderSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/stubs/enums/ContactTypeOrderSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.stubs.enums
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.libs.json.*
+
+class ContactTypeOrderSpec extends AnyWordSpec with Matchers {
+
+  "The ContactTypeOrder enum" must {
+
+    "serialize and deserialize all valid contact type order values" in {
+      val validContactTypeOrderValues = List(ContactTypeOrder.First, ContactTypeOrder.Second, ContactTypeOrder.Third)
+
+      validContactTypeOrderValues.foreach { value =>
+        val json   = Json.toJson(value)
+        val result = json.validate[ContactTypeOrder]
+        result mustBe JsSuccess(value)
+      }
+    }
+
+    "reject any invalid string values" in {
+      val invalidStringValues = List("Zero", "Fourth", "Fifth", "", "FIRST", "2nd")
+
+      invalidStringValues.foreach { value =>
+        val result = JsString(value).validate[ContactTypeOrder]
+        result mustBe a[JsError]
+        result.asInstanceOf[JsError].errors.head._2.head.message must equal(s"Unknown ContactTypeOrder value: $value")
+      }
+    }
+
+    "reject non-string JSON values" in {
+      val invalidNonStringValues = List(JsNumber(1), JsBoolean(true), JsNull, Json.obj("key" -> "value"))
+
+      invalidNonStringValues.foreach { value =>
+        val result = value.validate[ContactTypeOrder]
+        result mustBe a[JsError]
+        result.asInstanceOf[JsError].errors.head._2.head.message must include("ContactTypeOrder must be a string")
+      }
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/stubs/enums/Progress.scala
+++ b/src/test/scala/uk/gov/hmrc/stubs/enums/Progress.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,27 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.api.specs
+package uk.gov.hmrc.stubs.enums
 
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import uk.gov.hmrc.support.ApiTestSupport
+import play.api.libs.json.*
 
-trait BaseSpec extends AnyWordSpec with Matchers with ApiTestSupport {}
+import scala.util.Try
+
+enum Progress {
+  case Subscribed, Assigned, Notified, Certified
+}
+
+object Progress {
+  given Reads[Progress] = Reads {
+    case JsString(value) =>
+      Try(Progress.valueOf(value))
+        .map(JsSuccess(_))
+        .getOrElse(JsError(s"Unknown progress value: $value"))
+
+    case _ => JsError("String value expected for progress")
+  }
+
+  given Writes[Progress] = Writes { progress =>
+    JsString(progress.toString)
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/stubs/enums/ProgressSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/stubs/enums/ProgressSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.stubs.enums
+
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.libs.json.{JsBoolean, JsError, JsNull, JsNumber, JsString, JsSuccess, Json}
+
+class ProgressSpec extends AnyWordSpec with Matchers {
+
+  "The Progress enum" must {
+
+    "serialize and deserialize all valid progress values" in {
+      val validValues = List(Progress.Subscribed, Progress.Assigned, Progress.Notified, Progress.Certified)
+
+      validValues.foreach { progress =>
+        val json   = Json.toJson(progress)
+        val result = json.validate[Progress]
+        result mustBe JsSuccess(progress)
+      }
+    }
+
+    "reject any invalid string values" in {
+      val invalidStringValues = List("JarJar", "SUBSCRIBED", "invalid", "", "Subscribe")
+
+      invalidStringValues.foreach { value =>
+        val result = JsString(value).validate[Progress]
+        result mustBe a[JsError]
+        result.asInstanceOf[JsError].errors.head._2.head.message must equal(s"Unknown progress value: $value")
+      }
+    }
+
+    "reject non-string JSON values" in {
+      val invalidNonStringValues = List(JsNumber(123), JsBoolean(true), JsNull, Json.obj("key" -> "value"))
+
+      invalidNonStringValues.foreach { value =>
+        val result = value.validate[Progress]
+        result mustBe a[JsError]
+        result.asInstanceOf[JsError].errors.head._2.head.message must equal("String value expected for progress")
+      }
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/stubs/models/AccountingPeriod.scala
+++ b/src/test/scala/uk/gov/hmrc/stubs/models/AccountingPeriod.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,13 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.api.specs
+package uk.gov.hmrc.stubs.models
 
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import uk.gov.hmrc.support.ApiTestSupport
+import play.api.libs.json.{Json, OFormat}
+import java.time.Instant
 
-trait BaseSpec extends AnyWordSpec with Matchers with ApiTestSupport {}
+final case class AccountingPeriod(startDate: Instant, endDate: Instant, dueDate: Instant)
+
+object AccountingPeriod {
+  implicit val format: OFormat[AccountingPeriod] = Json.format[AccountingPeriod]
+}

--- a/src/test/scala/uk/gov/hmrc/stubs/models/BusinessEntity.scala
+++ b/src/test/scala/uk/gov/hmrc/stubs/models/BusinessEntity.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,22 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.api.specs
+package uk.gov.hmrc.stubs.models
 
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import uk.gov.hmrc.support.ApiTestSupport
+import play.api.libs.json.{Json, OFormat}
+import java.util.UUID
+import java.time.Instant
 
-trait BaseSpec extends AnyWordSpec with Matchers with ApiTestSupport {}
+final case class BusinessEntity(
+  id: UUID,
+  crn: String,
+  utr: String,
+  name: String,
+  contacts: List[Contact] = List.empty,
+  submissions: Option[List[Submission]] = None,
+  createdAt: Instant
+)
+
+object BusinessEntity {
+  implicit val format: OFormat[BusinessEntity] = Json.format[BusinessEntity]
+}

--- a/src/test/scala/uk/gov/hmrc/stubs/models/Contact.scala
+++ b/src/test/scala/uk/gov/hmrc/stubs/models/Contact.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,19 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.api.specs
+package uk.gov.hmrc.stubs.models
 
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import uk.gov.hmrc.support.ApiTestSupport
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.stubs.enums.ContactTypeOrder
 
-trait BaseSpec extends AnyWordSpec with Matchers with ApiTestSupport {}
+final case class Contact(
+  name: String,
+  role: String,
+  email: String,
+  phone: String,
+  order: ContactTypeOrder
+)
+
+object Contact {
+  implicit val format: OFormat[Contact] = Json.format[Contact]
+}

--- a/src/test/scala/uk/gov/hmrc/stubs/models/Submission.scala
+++ b/src/test/scala/uk/gov/hmrc/stubs/models/Submission.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,10 +14,20 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.api.specs
+package uk.gov.hmrc.stubs.models
 
-import org.scalatest.matchers.must.Matchers
-import org.scalatest.wordspec.AnyWordSpec
-import uk.gov.hmrc.support.ApiTestSupport
+import java.time.Instant
+import play.api.libs.json.*
+import uk.gov.hmrc.stubs.enums.Progress
 
-trait BaseSpec extends AnyWordSpec with Matchers with ApiTestSupport {}
+import java.time.temporal.ChronoUnit
+
+final case class Submission(
+  accountingPeriod: Option[AccountingPeriod],
+  receivedDate: Instant = Instant.now().truncatedTo(ChronoUnit.MINUTES),
+  progress: Progress = Progress.Subscribed
+)
+
+object Submission {
+  implicit val format: OFormat[Submission] = Json.format[Submission]
+}

--- a/src/test/scala/uk/gov/hmrc/support/ApiTestSupport.scala
+++ b/src/test/scala/uk/gov/hmrc/support/ApiTestSupport.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.support
+
+import org.scalatest.concurrent.ScalaFutures
+import uk.gov.hmrc.stubs.{ApiResponse, BusinessEntityApiStub}
+import uk.gov.hmrc.stubs.models.BusinessEntity
+import play.api.libs.json.Json
+import scala.concurrent.Future
+
+trait ApiTestSupport extends ScalaFutures {
+
+  object request {
+    private val baseUrl = "/senior-accounting-officer-hod/business-entity"
+
+    def put(entity: BusinessEntity): Future[ApiResponse] =
+      BusinessEntityApiStub.call(
+        method = "PUT",
+        url = baseUrl,
+        body = Some(Json.toJson(entity))
+      )
+
+    def putWithNoBody(): Future[ApiResponse] =
+      BusinessEntityApiStub.call(
+        method = "PUT",
+        url = baseUrl,
+        body = None
+      )
+
+    def putWithInvalidContentType(entity: BusinessEntity): Future[ApiResponse] =
+      BusinessEntityApiStub.call(
+        method = "PUT",
+        url = baseUrl,
+        body = Some(Json.toJson(entity)),
+        contentType = "text/plain"
+      )
+
+    def get(entityId: String): Future[ApiResponse] =
+      BusinessEntityApiStub.call(
+        method = "GET",
+        url = s"$baseUrl/$entityId"
+      )
+
+    def get(entityId: java.util.UUID): Future[ApiResponse] = get(entityId.toString)
+  }
+}


### PR DESCRIPTION
### Added
* Created stub for GET and PUT endpoints.
* Added skeleton tests for these endpoints, more specifically for the registration submission.
